### PR TITLE
Refactor mvnenv-exec to use mvnenv-root-dir

### DIFF
--- a/bin/mvnenv-exec
+++ b/bin/mvnenv-exec
@@ -14,11 +14,7 @@ if [ "${1}" == "--complete" ]; then
 fi
 
 if [ -z "${MVNENV_VERSION}" ]; then
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
-    ROOT_DIR=$(git rev-parse --show-toplevel)
-  else
-    ROOT_DIR="."
-  fi
+  ROOT_DIR=$("$(dirname "$0")/mvnenv-root-dir")
 
   if [ -e "${ROOT_DIR}/.mvn-version" ]; then
     CURVER=`cat "${ROOT_DIR}/.mvn-version"`

--- a/bin/mvnenv-root-dir
+++ b/bin/mvnenv-root-dir
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if git rev-parse --is-inside-work-tree &>/dev/null; then
+  git rev-parse --show-toplevel
+else
+  echo "."
+fi

--- a/test/mvnenv-root-dir.bats
+++ b/test/mvnenv-root-dir.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+}
+
+teardown() {
+  cd "$REPO_DIR"
+}
+
+given_git_repo() {
+  tmp_git_repo="$(mktemp -d)"
+  cd "$tmp_git_repo"
+  trap "rm -rf \"$tmp_git_repo\"" EXIT
+
+  git init -q
+  real_tmp_git_repo="$(cd "$tmp_git_repo" && pwd -P)"
+}
+
+given_git_repo_in_child_folder() {
+  tmp_git_repo="$(mktemp -d)"
+  cd "$tmp_git_repo"
+  trap "rm -rf \"$tmp_git_repo\"" EXIT
+
+  git init -q
+  real_tmp_git_repo="$(cd "$tmp_git_repo" && pwd -P)"
+
+  mkdir -p subdir/childdir
+  cd subdir/childdir
+}
+
+given_no_git_repo() {
+  tmp_dir="$(mktemp -d)"
+  cd "$tmp_dir"
+  trap "rm -rf \"$tmp_dir\"" EXIT
+}
+
+when_running_mvnenv_root_dir() {
+  run "$REPO_DIR/bin/mvnenv-root-dir"
+}
+
+then_returns_repo_root() {
+  [ "$status" -eq 0 ]
+  [ "$output" = "$real_tmp_git_repo" ]
+}
+
+then_returns_dot() {
+  [ "$status" -eq 0 ]
+  [ "$output" = "." ]
+}
+
+@test "given git repo when running mvnenv-root-dir then it returns the repo root" {
+  given_git_repo
+  when_running_mvnenv_root_dir
+  then_returns_repo_root
+}
+
+@test "given git repo when running mvnenv-root-dir from child folder then it returns the repo root" {
+  given_git_repo_in_child_folder
+  when_running_mvnenv_root_dir
+  then_returns_repo_root
+}
+
+@test "given no git repo when running mvnenv-root-dir then it returns dot" {
+  given_no_git_repo
+  when_running_mvnenv_root_dir
+  then_returns_dot
+}


### PR DESCRIPTION
Refactor mvnenv-exec to use mvnenv-root-dir script for determining root directory; add tests for mvnenv-root-dir functionality